### PR TITLE
Use rgba instead of a hex color code for background

### DIFF
--- a/dracula
+++ b/dracula
@@ -9,7 +9,7 @@
 foreground      = #f8f8f2
 foreground_bold = #f8f8f2
 cursor          = #f8f8f2
-background      = #282a36
+background      = rgba(40, 42, 51, 1)
 
 # black
 color0  = #000000


### PR DESCRIPTION
Termite natively supports transparency, which cannot be specified with a
hex color code, but can be specified with an rgba code.
This commit replaces the background's hex code with an equivalent rgba
code, with the last digit (1) representing the opacity (1 meaning 100%
opacity).