### PR TITLE
Remove cursor color

### DIFF
--- a/dracula
+++ b/dracula
@@ -8,7 +8,6 @@
 # special
 foreground      = #f8f8f2
 foreground_bold = #f8f8f2
-cursor          = #f8f8f2
 background      = rgba(40, 42, 54, 1)
 
 # black


### PR DESCRIPTION
Things under the cursor can't be seen clearly if the cursor and the foreground colors are the same, as shown below:
![before](https://user-images.githubusercontent.com/54680730/113998387-4f026380-9859-11eb-83da-35b335a1b2bb.png)

Unsetting the cursor color makes it use reverse colors for the foreground and background so that things under it can be seen easily, as show below:
![after](https://user-images.githubusercontent.com/54680730/113999397-4c543e00-985a-11eb-9bab-e5e607e4641c.png)
